### PR TITLE
Bump ClientOnly example dev dependencies to use latest

### DIFF
--- a/examples/ClientOnly/project.clj
+++ b/examples/ClientOnly/project.clj
@@ -96,9 +96,9 @@
   ;; Please see:
   ;; https://github.com/bhauman/
   ;;   (uri cont'd) lein-figwheel/wiki/Using-the-Figwheel-REPL-within-NRepl
-  :profiles {:dev {:dependencies [[binaryage/devtools "0.9.9"]
-                                  [figwheel-sidecar "0.5.16"]
-                                  [cider/piggieback "0.3.3"]]
+  :profiles {:dev {:dependencies [[binaryage/devtools "1.0.6"]
+                                  [figwheel-sidecar "0.5.18"]
+                                  [cider/piggieback "0.5.3"]]
                    ;; need to add dev source path here to get user.clj loaded
                    :source-paths ["src" "dev"]
                    ;; for CIDER


### PR DESCRIPTION
The Figwheel Sidecar dependency was using version 0.5.16, which throws Calva out of whack. I bumped it to 0.5.18 and also bumped the other `dev` dependencies while at it.

Fixes: BetterThanTomorrow/calva#1892