### PR TITLE
x2 & y2 support

### DIFF
--- a/src/cljc/aerial/hanami/common.cljc
+++ b/src/cljc/aerial/hanami/common.cljc
@@ -165,6 +165,28 @@
          :YSCALE RMV, :YSTACK RMV
          :YAXIS {:title :YTITLE, :grid :YGRID, :format :YFORMAT}
          :YTITLE RMV, :YGRID RMV, :YFORMAT RMV, :YTTITLE RMV, :YTFMT RMV
+         :X2TYPE (fn [ctx]
+                   (if (-> ctx :X2 (not= RMV))
+                     (:XTYPE ctx)
+                     RMV))
+         :Y2TYPE (fn [ctx]
+                   (if (-> ctx :Y2 (not= RMV))
+                     (:YTYPE ctx)
+                     RMV))
+         :X2ENCODING (fn [ctx]
+                       (if (-> ctx :X2 (not= RMV))
+                         (-> ht/xy-encoding
+                             :x
+                             (assoc :field :X2
+                                    :type :X2TYPE))
+                         RMV))
+         :Y2ENCODING (fn [ctx]
+                       (if (-> ctx :Y2 (not= RMV))
+                         (-> ht/xy-encoding
+                             :y
+                             (assoc :field :Y2
+                                    :type :Y2TYPE))
+                         RMV))
          :TXT RMV, :TTYPE RMV, :TAXIS RMV, :TSCALE RMV
          :ROWDEF ht/default-row :ROW RMV, :ROWTYPE RMV
          :COLDEF ht/default-col :COLUMN RMV, :COLTYPE RMV
@@ -193,8 +215,8 @@
                      :fillOpacity 0.125,
                      :stroke "white"},
          :SMDWN-MARK {:fill "#333",
-                     :fillOpacity 0.125,
-                     :stroke "white"}
+                      :fillOpacity 0.125,
+                      :stroke "white"}
          :SELECTION RMV, :ENCODINGS ["x", "y"], :IRESOLVE "global"
 
          ;; Mark Properties
@@ -319,4 +341,3 @@
      (xform spec start-kv-map)))
 
   ([spec] (xform spec {})))
-

--- a/src/cljc/aerial/hanami/common.cljc
+++ b/src/cljc/aerial/hanami/common.cljc
@@ -166,22 +166,22 @@
          :YAXIS {:title :YTITLE, :grid :YGRID, :format :YFORMAT}
          :YTITLE RMV, :YGRID RMV, :YFORMAT RMV, :YTTITLE RMV, :YTFMT RMV
          :X2TYPE (fn [ctx]
-                   (if (-> ctx :X2 (not= RMV))
+                   (if (:X2 ctx)
                      (:XTYPE ctx)
                      RMV))
          :Y2TYPE (fn [ctx]
-                   (if (-> ctx :Y2 (not= RMV))
+                   (if (:Y2 ctx)
                      (:YTYPE ctx)
                      RMV))
          :X2ENCODING (fn [ctx]
-                       (if (-> ctx :X2 (not= RMV))
+                       (if (:X2 ctx)
                          (-> ht/xy-encoding
                              :x
                              (assoc :field :X2
                                     :type :X2TYPE))
                          RMV))
          :Y2ENCODING (fn [ctx]
-                       (if (-> ctx :Y2 (not= RMV))
+                       (if (:Y2 ctx)
                          (-> ht/xy-encoding
                              :y
                              (assoc :field :Y2

--- a/src/cljc/aerial/hanami/templates.cljc
+++ b/src/cljc/aerial/hanami/templates.cljc
@@ -203,13 +203,13 @@
    :encoding :ENCODING})
 
 (def rule-layer
-  {:mark (assoc ht/mark-base :type "rule")
+  {:mark (assoc mark-base :type "rule")
    :selection :SELECTION
    :transform :TRANSFORM
    :encoding :ENCODING})
 
 (def rect-layer
-  {:mark (assoc ht/mark-base :type "rect")
+  {:mark (assoc mark-base :type "rect")
    :selection :SELECTION
    :transform :TRANSFORM
    :encoding :ENCODING})
@@ -246,11 +246,11 @@
          :mark (merge mark-base {:type "boxplot"})))
 
 (def rule-chart
-  (assoc ht/view-base
+  (assoc view-base
          :mark "rule"))
 
 (def rect-chart
-  (assoc ht/view-base
+  (assoc view-base
          :mark "rect"))
 
 (def layer-chart

--- a/src/cljc/aerial/hanami/templates.cljc
+++ b/src/cljc/aerial/hanami/templates.cljc
@@ -202,12 +202,6 @@
    :transform :TRANSFORM
    :encoding :ENCODING})
 
-(def rule-layer
-  {:mark (assoc mark-base :type "rule")
-   :selection :SELECTION
-   :transform :TRANSFORM
-   :encoding :ENCODING})
-
 (def gen-encode-layer
   {:height :HEIGHT, :width :WIDTH
    :mark :MARK

--- a/src/cljc/aerial/hanami/templates.cljc
+++ b/src/cljc/aerial/hanami/templates.cljc
@@ -202,6 +202,18 @@
    :transform :TRANSFORM
    :encoding :ENCODING})
 
+(def rule-layer
+  {:mark (assoc ht/mark-base :type "rule")
+   :selection :SELECTION
+   :transform :TRANSFORM
+   :encoding :ENCODING})
+
+(def rect-layer
+  {:mark (assoc ht/mark-base :type "rect")
+   :selection :SELECTION
+   :transform :TRANSFORM
+   :encoding :ENCODING})
+
 (def gen-encode-layer
   {:height :HEIGHT, :width :WIDTH
    :mark :MARK
@@ -232,6 +244,14 @@
 (def boxplot-chart
   (assoc view-base
          :mark (merge mark-base {:type "boxplot"})))
+
+(def rule-chart
+  (assoc ht/view-base
+         :mark "rule"))
+
+(def rect-chart
+  (assoc ht/view-base
+         :mark "rect"))
 
 (def layer-chart
   {:usermeta :USERDATA

--- a/src/cljc/aerial/hanami/templates.cljc
+++ b/src/cljc/aerial/hanami/templates.cljc
@@ -208,12 +208,6 @@
    :transform :TRANSFORM
    :encoding :ENCODING})
 
-(def rect-layer
-  {:mark (assoc mark-base :type "rect")
-   :selection :SELECTION
-   :transform :TRANSFORM
-   :encoding :ENCODING})
-
 (def gen-encode-layer
   {:height :HEIGHT, :width :WIDTH
    :mark :MARK

--- a/src/cljc/aerial/hanami/templates.cljc
+++ b/src/cljc/aerial/hanami/templates.cljc
@@ -99,7 +99,9 @@
        :scale :YSCALE
        :stack :YSTACK
        :sort :YSORT
-       :aggregate :YAGG}))
+       :aggregate :YAGG}
+   :x2 :X2ENCODING
+   :y2 :Y2ENCODING))
 
 (def text-encoding
   (-> encoding-base


### PR DESCRIPTION
* adding support for `:x2`, `:y2` encodings
* adding a couple of layers and templates that require `:x2`. `:y2` encodings

This PR is an adaptation adapted from experimental code at [Noj](https://scicloj.github.io/noj/) and @jsa-aerial's comments.

Zulip discussion:
https://clojurians.zulipchat.com/#narrow/stream/210075-saite-dev/topic/templates/near/418527086